### PR TITLE
clearVis will not clear if component isDestroying is true

### DIFF
--- a/addon/components/vega-vis.js
+++ b/addon/components/vega-vis.js
@@ -625,7 +625,7 @@ export default Component.extend({
             isDestroyed
         } = getProperties(this, 'isDestroying', 'isDestroyed');
 
-        if (!isDestroyed || isDestroying) {
+        if (!isDestroyed || !isDestroying) {
             set(this, 'vis', null);
         }
     },


### PR DESCRIPTION
clearVis was incorrectly checking whether the component was `isDestroying` to see whether or not to set `vis` to null and caused acceptance tests to fail.

![Screen Shot 2020-03-23 at 1 40 36 PM](https://user-images.githubusercontent.com/35976726/77361116-e4dd5600-6d0b-11ea-9813-ae9f8b05bbe9.png)
