### PR TITLE
Address setting vis to null in a scheduled runloop during willDestoryElement

### DIFF
--- a/addon/components/vega-vis.js
+++ b/addon/components/vega-vis.js
@@ -625,7 +625,7 @@ export default Component.extend({
             isDestroyed
         } = getProperties(this, 'isDestroying', 'isDestroyed');
 
-        if (!isDestroyed || !isDestroying) {
+        if (!isDestroyed || isDestroying) {
             set(this, 'vis', null);
         }
     },
@@ -724,7 +724,12 @@ export default Component.extend({
     willDestroyElement() {
         this._super(...arguments);
 
-        scheduleOnce('afterRender', this, 'clearVis');
+        /**
+         * Clear without scheduling because scheduling introduces a race condition where a two-way-bound property gets nulled
+         * on a "parent" component/controller that has been destroyed. Without scheduling, the two-way-bound property changes without
+         * trying to set on a destroyed component/controller.
+         */
+        this.clearVis();
     },
 
     /**

--- a/addon/components/vega-vis.js
+++ b/addon/components/vega-vis.js
@@ -724,11 +724,9 @@ export default Component.extend({
     willDestroyElement() {
         this._super(...arguments);
 
-        /**
-         * Clear without scheduling because scheduling introduces a race condition where a two-way-bound property gets nulled
-         * on a "parent" component/controller that has been destroyed. Without scheduling, the two-way-bound property changes without
-         * trying to set on a destroyed component/controller.
-         */
+        // Clear without scheduling because scheduling introduces a race condition where a two-way-bound property gets nulled
+        // on a "parent" component/controller that has been destroyed. Without scheduling, the two-way-bound property changes without
+        // trying to set on a destroyed component/controller.
         this.clearVis();
     },
 


### PR DESCRIPTION
Address setting vis to null in a scheduled runloop during willDestoryElement.
The issue is that scheduling `cleanVis` causes race condition when trying to set `vis` on a two-way-bound property where the parent component or controller is already destroyed.